### PR TITLE
ドメイン移行: itsme-app.com → itsme-types.com（DNS分離設定対応）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # its-me-lp
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/3a29fb44-0d56-453d-aef4-6a91982352bd/deploy-status)](https://app.netlify.com/projects/itsme-types/deploys)
+

--- a/es/index.html
+++ b/es/index.html
@@ -23,27 +23,27 @@
     <meta property="og:title" content="It's Me - Evaluación de Valores × Asesor IA">
     <meta property="og:description" content="Descubre tu verdadero yo a través de 48 preguntas. Tu asesor personal de IA te ayuda a dar pasos positivos hacia adelante.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/es/">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/es/">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/es/">
+    <link rel="canonical" href="https://itsme-types.com/es/">
     
     <!-- Hreflang Tags for International SEO -->
-    <link rel="alternate" hreflang="en" href="https://itsme-app.com/">
-    <link rel="alternate" hreflang="es" href="https://itsme-app.com/es/">
-    <link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/">
-    <link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/">
-    <link rel="alternate" hreflang="x-default" href="https://itsme-app.com/">
+    <link rel="alternate" hreflang="en" href="https://itsme-types.com/">
+    <link rel="alternate" hreflang="es" href="https://itsme-types.com/es/">
+    <link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/">
+    <link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://itsme-types.com/">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="It's Me - Evaluación de Valores × Asesor IA">
     <meta name="twitter:description" content="Descubre tu verdadero yo a través de 48 preguntas. Tu asesor personal de IA te ayuda a dar pasos positivos hacia adelante.">
-    <meta name="twitter:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta name="twitter:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -52,7 +52,7 @@
       "@type": "WebApplication",
       "name": "It's Me - Evaluación de Valores",
       "description": "Descubre tu verdadero yo a través de 48 preguntas. Tu asesor personal de IA te ayuda a dar pasos positivos hacia adelante.",
-      "url": "https://itsme-app.com/es/",
+      "url": "https://itsme-types.com/es/",
       "applicationCategory": "Lifestyle",
       "operatingSystem": "iOS, Android",
       "offers": {

--- a/es/privacy-policy.html
+++ b/es/privacy-policy.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="Política de Privacidad - It's Me">
     <meta property="og:description" content="Política de Privacidad de la aplicación de evaluación de valores It's Me. Aprende cómo protegemos tu información personal y datos.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/es/privacy-policy.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/es/privacy-policy.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/es/privacy-policy.html">
+    <link rel="canonical" href="https://itsme-types.com/es/privacy-policy.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/es/terms-of-service.html
+++ b/es/terms-of-service.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="Términos de Servicio - It's Me">
     <meta property="og:description" content="Términos de Servicio de la aplicación de evaluación de valores It's Me. Conoce nuestros términos y condiciones para usar el servicio.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/es/terms-of-service.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/es/terms-of-service.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/es/terms-of-service.html">
+    <link rel="canonical" href="https://itsme-types.com/es/terms-of-service.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -29,27 +29,27 @@
     <meta property="og:title" content="It's Me - Values Assessment × AI Advisor">
     <meta property="og:description" content="Discover your true self through 48 questions. Your personal AI advisor helps you take positive steps forward.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/">
+    <link rel="canonical" href="https://itsme-types.com/">
     
     <!-- Hreflang Tags for International SEO -->
-    <link rel="alternate" hreflang="en" href="https://itsme-app.com/">
-    <link rel="alternate" hreflang="es" href="https://itsme-app.com/es/">
-    <link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/">
-    <link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/">
-    <link rel="alternate" hreflang="x-default" href="https://itsme-app.com/">
+    <link rel="alternate" hreflang="en" href="https://itsme-types.com/">
+    <link rel="alternate" hreflang="es" href="https://itsme-types.com/es/">
+    <link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/">
+    <link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://itsme-types.com/">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="It's Me - Values Assessment × AI Advisor">
     <meta name="twitter:description" content="Discover your true self through 48 questions. Your personal AI advisor helps you take positive steps forward.">
-    <meta name="twitter:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta name="twitter:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -58,7 +58,7 @@
       "@type": "WebApplication",
       "name": "It's Me - Values Assessment",
       "description": "Discover your true self through 48 questions. Your personal AI advisor helps you take positive steps forward.",
-      "url": "https://itsme-app.com",
+      "url": "https://itsme-types.com",
       "applicationCategory": "Lifestyle",
       "operatingSystem": "iOS, Android",
       "offers": {

--- a/ja/index.html
+++ b/ja/index.html
@@ -29,27 +29,27 @@
     <meta property="og:title" content="It's Me - 価値観診断 × AIアドバイザー">
     <meta property="og:description" content="48の質問で本当の自分を発見。あなただけのAIアドバイザーが、前向きな一歩を踏み出すお手伝いをします。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ja/">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ja/">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ja/">
+    <link rel="canonical" href="https://itsme-types.com/ja/">
     
     <!-- Hreflang Tags for International SEO -->
-    <link rel="alternate" hreflang="en" href="https://itsme-app.com/">
-    <link rel="alternate" hreflang="es" href="https://itsme-app.com/es/">
-    <link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/">
-    <link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/">
-    <link rel="alternate" hreflang="x-default" href="https://itsme-app.com/">
+    <link rel="alternate" hreflang="en" href="https://itsme-types.com/">
+    <link rel="alternate" hreflang="es" href="https://itsme-types.com/es/">
+    <link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/">
+    <link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://itsme-types.com/">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="It's Me - 価値観診断 × AIアドバイザー">
     <meta name="twitter:description" content="48の質問で本当の自分を発見。あなただけのAIアドバイザーが、前向きな一歩を踏み出すお手伝いをします。">
-    <meta name="twitter:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta name="twitter:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -58,7 +58,7 @@
       "@type": "WebApplication",
       "name": "It's Me - 価值观診断",
       "description": "48の質問で本当の自分を発見。あなただけのAIアドバイザーが、前向きな一歩を踏み出すお手伝いをします。",
-      "url": "https://itsme-app.com/ja/",
+      "url": "https://itsme-types.com/ja/",
       "applicationCategory": "Lifestyle",
       "operatingSystem": "iOS, Android",
       "offers": {

--- a/ja/privacy-policy.html
+++ b/ja/privacy-policy.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="プライバシーポリシー - It's Me">
     <meta property="og:description" content="It's Me価値観診断アプリのプライバシーポリシー。個人情報の取り扱いとデータ保護について説明します。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ja/privacy-policy.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ja/privacy-policy.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ja/privacy-policy.html">
+    <link rel="canonical" href="https://itsme-types.com/ja/privacy-policy.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/ja/terms-of-service.html
+++ b/ja/terms-of-service.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="利用規約 - It's Me">
     <meta property="og:description" content="It's Me価値観診断アプリの利用規約。サービス利用に関する条件と規約について説明します。">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ja/terms-of-service.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ja/terms-of-service.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ja/terms-of-service.html">
+    <link rel="canonical" href="https://itsme-types.com/ja/terms-of-service.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/ko/index.html
+++ b/ko/index.html
@@ -29,27 +29,27 @@
     <meta property="og:title" content="It's Me - 가치관 진단 × AI 어드바이저">
     <meta property="og:description" content="48개의 질문으로 진짜 나를 발견하세요. 당신만의 AI 어드바이저가 긍정적인 한 걸음을 내딛는 데 도움을 드립니다.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ko/">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ko/">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ko/">
+    <link rel="canonical" href="https://itsme-types.com/ko/">
     
     <!-- Hreflang Tags for International SEO -->
-    <link rel="alternate" hreflang="en" href="https://itsme-app.com/">
-    <link rel="alternate" hreflang="es" href="https://itsme-app.com/es/">
-    <link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/">
-    <link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/">
-    <link rel="alternate" hreflang="x-default" href="https://itsme-app.com/">
+    <link rel="alternate" hreflang="en" href="https://itsme-types.com/">
+    <link rel="alternate" hreflang="es" href="https://itsme-types.com/es/">
+    <link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/">
+    <link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/">
+    <link rel="alternate" hreflang="x-default" href="https://itsme-types.com/">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="It's Me - 가치관 진단 × AI 어드바이저">
     <meta name="twitter:description" content="48개의 질문으로 진짜 나를 발견하세요. 당신만의 AI 어드바이저가 긍정적인 한 걸음을 내딛는 데 도움을 드립니다.">
-    <meta name="twitter:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta name="twitter:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -58,7 +58,7 @@
       "@type": "WebApplication",
       "name": "It's Me - 가치관 진단",
       "description": "48개의 질문으로 진짜 나를 발견하세요. 당신만의 AI 어드바이저가 긍정적인 한 걸음을 내딛는 데 도움을 드립니다.",
-      "url": "https://itsme-app.com/ko/",
+      "url": "https://itsme-types.com/ko/",
       "applicationCategory": "Lifestyle",
       "operatingSystem": "iOS, Android",
       "offers": {

--- a/ko/privacy-policy.html
+++ b/ko/privacy-policy.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="개인정보처리방침 - It's Me">
     <meta property="og:description" content="It's Me 가치관 진단 애플리케이션의 개인정보처리방침. 개인정보 보호 및 데이터 처리 방법에 대해 알아보세요.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ko/privacy-policy.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ko/privacy-policy.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ko/privacy-policy.html">
+    <link rel="canonical" href="https://itsme-types.com/ko/privacy-policy.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/ko/terms-of-service.html
+++ b/ko/terms-of-service.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="이용약관 - It's Me">
     <meta property="og:description" content="It's Me 가치관 진단 애플리케이션의 이용약관. 서비스 이용에 관한 조건과 약관에 대해 알아보세요.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/ko/terms-of-service.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/ko/terms-of-service.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/ko/terms-of-service.html">
+    <link rel="canonical" href="https://itsme-types.com/ko/terms-of-service.html">
     
     <link rel="stylesheet" href="../assets/css/style.css">
 </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,13 @@
   status = 301
   force = true
 
+# Redirect /app/* to Firebase Hosting subdomain
+[[redirects]]
+  from = "/app/*"
+  to = "https://app.itsme-types.com/:splat"
+  status = 301
+  force = true
+
 # Language-based redirects for root path
 [[redirects]]
   from = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,79 @@
+[build]
+  publish = "."
+  command = "echo 'Static site, no build command needed'"
+
+# Redirect from old domain to new domain
+[[redirects]]
+  from = "https://itsme-app.com/*"
+  to = "https://itsme-types.com/:splat"
+  status = 301
+  force = true
+
+# Language-based redirects for root path
+[[redirects]]
+  from = "/"
+  to = "/ja/"
+  status = 302
+  conditions = {Language = ["ja"]}
+
+[[redirects]]
+  from = "/"
+  to = "/ko/"
+  status = 302
+  conditions = {Language = ["ko"]}
+
+[[redirects]]
+  from = "/"
+  to = "/es/"
+  status = 302
+  conditions = {Language = ["es"]}
+
+# Default fallback to Japanese (most common user base)
+[[redirects]]
+  from = "/"
+  to = "/ja/"
+  status = 302
+
+# 404 page handling
+[[redirects]]
+  from = "/*"
+  to = "/404.html"
+  status = 404
+
+# Security headers (complement existing _headers file)
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-XSS-Protection = "1; mode=block"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+
+# Cache control for static assets
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.css"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/*.js"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# PWA manifest cache
+[[headers]]
+  for = "/manifest.json"
+  [headers.values]
+    Cache-Control = "public, max-age=86400"
+
+# HTML pages - shorter cache with revalidation
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "public, max-age=3600, must-revalidate"

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="Privacy Policy - It's Me">
     <meta property="og:description" content="Privacy Policy for It's Me values assessment application. Learn how we protect your personal information and data.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/privacy-policy.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/privacy-policy.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/privacy-policy.html">
+    <link rel="canonical" href="https://itsme-types.com/privacy-policy.html">
     
     <link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/robots.txt
+++ b/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 
 # Sitemap
-Sitemap: https://itsme-app.com/sitemap.xml
+Sitemap: https://itsme-types.com/sitemap.xml
 
 # Disallow specific files
 Disallow: /manifest.json

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,47 +2,47 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>https://itsme-app.com/</loc>
+    <loc>https://itsme-types.com/</loc>
     <lastmod>2025-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-app.com/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-app.com/es/" />
-    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/" />
-    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-app.com/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-types.com/" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-types.com/es/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/" />
+    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-types.com/" />
   </url>
   <url>
-    <loc>https://itsme-app.com/es/</loc>
+    <loc>https://itsme-types.com/es/</loc>
     <lastmod>2025-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-app.com/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-app.com/es/" />
-    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/" />
-    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-app.com/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-types.com/" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-types.com/es/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/" />
+    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-types.com/" />
   </url>
   <url>
-    <loc>https://itsme-app.com/ja/</loc>
+    <loc>https://itsme-types.com/ja/</loc>
     <lastmod>2025-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-app.com/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-app.com/es/" />
-    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/" />
-    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-app.com/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-types.com/" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-types.com/es/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/" />
+    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-types.com/" />
   </url>
   <url>
-    <loc>https://itsme-app.com/ko/</loc>
+    <loc>https://itsme-types.com/ko/</loc>
     <lastmod>2025-01-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-app.com/" />
-    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-app.com/es/" />
-    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-app.com/ja/" />
-    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-app.com/ko/" />
-    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-app.com/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://itsme-types.com/" />
+    <xhtml:link rel="alternate" hreflang="es" href="https://itsme-types.com/es/" />
+    <xhtml:link rel="alternate" hreflang="ja" href="https://itsme-types.com/ja/" />
+    <xhtml:link rel="alternate" hreflang="ko" href="https://itsme-types.com/ko/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://itsme-types.com/" />
   </url>
 </urlset>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -29,14 +29,14 @@
     <meta property="og:title" content="Terms of Service - It's Me">
     <meta property="og:description" content="Terms of Service for It's Me values assessment application. Learn about our terms and conditions for using the service.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://itsme-app.com/terms-of-service.html">
-    <meta property="og:image" content="https://itsme-app.com/assets/images/app_icon/Icon-512.png">
+    <meta property="og:url" content="https://itsme-types.com/terms-of-service.html">
+    <meta property="og:image" content="https://itsme-types.com/assets/images/app_icon/Icon-512.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
     <meta property="og:site_name" content="It's Me">
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://itsme-app.com/terms-of-service.html">
+    <link rel="canonical" href="https://itsme-types.com/terms-of-service.html">
     
     <link rel="stylesheet" href="assets/css/style.css">
 </head>


### PR DESCRIPTION
## 概要

Issue #6のドメイン移行を完了しました。`itsme-app.com`から`itsme-types.com`への完全移行と、DNS分離アーキテクチャの設定を実装。

• **ドメイン移行**: 15ファイル、85箇所のURL参照を更新
• **DNS分離対応**: `itsme-types.com`（Netlify LP）+ `app.itsme-types.com`（Firebase Hosting）
• **Netlify設定**: 多言語ルーティング、セキュリティヘッダー、キャッシュ最適化
• **SEO対応**: 301リダイレクト、canonical URL、sitemap、robots.txt更新

## 変更内容

### 主要ファイル更新
- **sitemap.xml**: 全言語版のURL参照24箇所を更新
- **robots.txt**: サイトマップURLを更新
- **netlify.toml**: リダイレクト設定と最適化を含む新規デプロイメント設定

### 多言語ページ（4言語 × 3ページタイプ = 12ファイル）
- **メインページ**: `index.html`、`ja/`、`ko/`、`es/`（36箇所）
- **プライバシーポリシー**: 全言語版（12箇所）
- **利用規約**: 全言語版（12箇所）

### 更新したメタタグ
- Open Graph URL（`og:url`、`og:image`）
- 正規URL（`rel="canonical"`）
- 構造化データのJSON-LD URL

## デプロイメント構成

```
itsme-types.com（ルートドメイン）
├── Netlifyホスティング（ランディングページ）
├── 多言語ルーティング（/ja/、/ko/、/es/）
├── itsme-app.comからの301リダイレクト
└── 将来対応: app.itsme-types.com → Firebase Hosting
```

## テスト計画

- [ ] Netlifyプレビューで全ページの正常表示を確認
- [ ] 多言語ルーティング機能をテスト
- [ ] 旧ドメインからの301リダイレクトを確認
- [ ] SEOメタタグとサイトマップを検証
- [ ] PWAマニフェスト機能をチェック
- [ ] 404ページの動作を確認

## 技術詳細

### netlify.toml設定内容
- 旧ドメインからの301リダイレクト（SEO評価継承）
- ブラウザ言語による自動振り分け
- セキュリティヘッダー強化
- 静的アセットのキャッシュ最適化
- カスタム404ページ設定

### 変更統計
- 16ファイル変更：172行追加、90行削除
- 新規作成：netlify.toml（79行）
- ドメイン参照更新：85箇所

🤖 Generated with [Claude Code](https://claude.ai/code)