### PR TITLE
プライバシーポリシーと利用規約ページの言語切り替えナビゲーション問題を修正

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -145,10 +145,10 @@ function initLanguageSwitcher() {
         }
         
         const langPaths = {
-            'en': isSubpage ? `../${targetFile}` : `./${targetFile}`,
-            'ja': isSubpage ? `../ja/${targetFile}` : `./ja/${targetFile}`,
-            'ko': isSubpage ? `../ko/${targetFile}` : `./ko/${targetFile}`,
-            'es': isSubpage ? `../es/${targetFile}` : `./es/${targetFile}`
+            'en': `/${targetFile}`,
+            'ja': `/ja/${targetFile}`,
+            'ko': `/ko/${targetFile}`,
+            'es': `/es/${targetFile}`
         };
         
         if (langPaths[langCode]) {


### PR DESCRIPTION
## Summary
- プライバシーポリシーと利用規約ページで言語を変更すると、index.htmlに遷移してしまうバグを修正
- `navigateToLanguage`関数の相対パスロジックを絶対パスに変更
- 全てのページタイプから正しく言語切り替えが動作することを保証

## Test plan
- [ ] 英語のプライバシーポリシーページから他言語のプライバシーポリシーページへの遷移
- [ ] 日本語のプライバシーポリシーページから他言語のプライバシーポリシーページへの遷移
- [ ] 韓国語の利用規約ページから他言語の利用規約ページへの遷移
- [ ] スペイン語の利用規約ページから他言語の利用規約ページへの遷移
- [ ] index.htmlでの言語切り替えが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)